### PR TITLE
BufferOverflow fix + HTTP Header size max

### DIFF
--- a/Source/Core/NptHttp.cpp
+++ b/Source/Core/NptHttp.cpp
@@ -180,6 +180,8 @@ NPT_HttpHeaders::Parse(NPT_BufferedInputStream& stream)
             break;
         }
         if (header_pending && (line[0] == ' ' || line[0] == '\t')) {
+            // limit size of multiline header
+            if (header_value.GetLength() >= NPT_HTTP_PROTOCOL_MAX_LINE_LENGTH) continue;
             // continuation (folded header)
             header_value.Append(line.GetChars()+1, line.GetLength()-1);
         } else {

--- a/Source/Core/NptStrings.cpp
+++ b/Source/Core/NptStrings.cpp
@@ -377,6 +377,9 @@ NPT_String::Append(const char* str, NPT_Size length)
     NPT_Size old_length = GetLength();
     NPT_Size new_length = old_length + length;
 
+    // avoid Buffer Overflow
+    if(new_length < old_length) return;
+
     // allocate enough space
     Reserve(new_length);
     


### PR DESCRIPTION
the following changes fix a buffer overflow in String.append and set an upper limit to the size of a single HTTP-Header in order to improve robustness.

The buffer overflow results if there is an overflow in NPT_Size (32bit int) as the Reserve function does not update if the new size is smaller. So data is written in unused mem