### PR TITLE
Fix mismatching alloc/dealloc

### DIFF
--- a/Source/Apps/NetPump/NetPump.cpp
+++ b/Source/Apps/NetPump/NetPump.cpp
@@ -674,7 +674,7 @@ main(int argc, char** argv)
         exit(1);
     }
     
-    delete[] buffer;
+    free(buffer);
     return 0;
 }
 


### PR DESCRIPTION
Cppcheck found this issue:
Mismatching allocation and deallocation: buffer
NetPump.cpp line="677"